### PR TITLE
Adiciona XlsxWriter para suporte a exportação Excel

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ mysql-connector-python>=8.0.0
 requests>=2.28.0
 SQLAlchemy>=2.0.0
 typing_extensions>=4.0.0
+XlsxWriter>=3.1.9


### PR DESCRIPTION
- Adiciona XlsxWriter aos requirements.txt
- Corrige erro "No module named xlsxwriter" no Streamlit Cloud
- Permite exportação para Excel nas páginas do dashboard