### PR TITLE
Update app_completo.py to use logo.svg.svg

### DIFF
--- a/app_completo.py
+++ b/app_completo.py
@@ -7,6 +7,35 @@ import requests
 import json
 import time
 import io
+import base64
+from datetime import datetime, timedelta
+
+# Carregar o logo para usar como ícone
+def get_logo_base64():
+    try:
+        with open("logo.svg.svg", "rb") as f:
+            return base64.b64encode(f.read()).decode()
+    except Exception as e:
+        print(f"Erro ao carregar logo: {e}")
+        return None
+
+# Configurações básicas do Streamlit
+logo_base64 = get_logo_base64()
+st.set_page_config(
+    page_title="Eu na Europa - Sistema de Relatórios",
+    page_icon=f"data:image/svg+xml;base64,{logo_base64}" if logo_base64 else "🌍",
+    layout="wide",
+    initial_sidebar_state="expanded"
+)
+import streamlit as st
+import pandas as pd
+import plotly.express as px
+import mysql.connector
+from mysql.connector import Error
+import requests
+import json
+import time
+import io
 from datetime import datetime, timedelta
 
 # Configurações básicas do Streamlit


### PR DESCRIPTION
## Mudanças

- Atualizado app_completo.py para usar o logo.svg.svg como ícone
- O logo é carregado do arquivo na raiz do projeto
- Adicionada função get_logo_base64() para carregar o logo
- Configurado o logo como ícone da página

## Notas
- O logo é carregado do arquivo logo.svg.svg
- Se o logo não puder ser carregado, usa o ícone 🌍 como fallback
- O logo é usado tanto no ícone da página quanto no sidebar