### PR TITLE
Fix duplicated code in app_completo.py

### DIFF
--- a/app_completo.py
+++ b/app_completo.py
@@ -27,27 +27,11 @@ st.set_page_config(
     layout="wide",
     initial_sidebar_state="expanded"
 )
-import streamlit as st
-import pandas as pd
-import plotly.express as px
-import mysql.connector
-from mysql.connector import Error
-import requests
-import json
-import time
-import io
-from datetime import datetime, timedelta
 
-# Configurações básicas do Streamlit
-st.set_page_config(
-    page_title="Eu na Europa - Sistema de Relatórios",
-    page_icon="🌍",
-    layout="wide",
-    initial_sidebar_state="expanded"
-)
 """
 Eu na Europa - Sistema de Relatórios
 Versão consolidada para Streamlit Cloud
+"""
 """
 import streamlit as st
 import pandas as pd


### PR DESCRIPTION
## Problema
O arquivo app_completo.py tinha código duplicado, incluindo duas chamadas para st.set_page_config(), o que estava causando erro no Streamlit Cloud.

## Solução
- Removido código duplicado
- Mantida apenas uma chamada para st.set_page_config()
- Mantida a configuração do logo.svg.svg como ícone

## Notas
- O arquivo app_completo.py agora está mais limpo e organizado
- O logo é carregado corretamente do arquivo logo.svg.svg
- Isso deve resolver o erro de conexão recusada no Streamlit Cloud